### PR TITLE
Fix FI API route and model

### DIFF
--- a/backend/app/api/fi_router.py
+++ b/backend/app/api/fi_router.py
@@ -5,12 +5,12 @@ from ..models.fi_models import FIRequestData, FinancialIndependenceResult, UserF
 from ..dependencies import get_fi_service
 
 router = APIRouter(
-    prefix="/fi", # All routes in this router will start with /fi
-    tags=["Financial Independence"], # Tag for API documentation
+    prefix="/api/fi",  # Align with other API routes
+    tags=["Financial Independence"],
 )
 
-@router.post("/calculate-status", response_model=FinancialIndependenceResult)
-async def calculate_financial_independence_status(
+@router.post("/calculate", response_model=FinancialIndependenceResult)
+async def calculate_financial_independence(
     request_data: FIRequestData,
     fi_service: FIService = Depends(get_fi_service)
 ) -> FinancialIndependenceResult:
@@ -54,3 +54,4 @@ async def get_fi_summary(
 # async def get_fi_parameters_schema():
 #     """Returns the schema for User FI Parameters."""
 #     return UserFIParameters.model_json_schema()
+

--- a/backend/app/models/fi_models.py
+++ b/backend/app/models/fi_models.py
@@ -34,4 +34,6 @@ class FinancialIndependenceResult(BaseModel):
 
 # Model for the request body - only UserFIParameters are needed from the client
 class FIRequestData(BaseModel):
-    user_fi_parameters: UserFIParameters 
+    """Parameters supplied by the client for FI calculations."""
+    user_fi_parameters: UserFIParameters
+

--- a/ui/src/services/fiService.ts
+++ b/ui/src/services/fiService.ts
@@ -1,8 +1,8 @@
 import { UserFIParameters, FinancialIndependenceResult } from '../types/fiTypes';
 
 // Consistent with other API calls in App.tsx, using the full direct URL.
-// The backend FI router has a prefix /fi and the endpoint is /calculate-status.
-const API_ENDPOINT = 'http://localhost:5001/fi/calculate-status';
+// The backend FI router now uses the /api/fi prefix and the endpoint is /calculate.
+const API_ENDPOINT = 'http://localhost:5001/api/fi/calculate';
 
 export async function calculateFIStatus(
     params: UserFIParameters


### PR DESCRIPTION
## Summary
- repair truncated FIRequestData model
- align FI router endpoints with `/api` prefix and adjust calculate route
- update UI `fiService` to hit the new endpoint

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npm run build` *(fails: Cannot find module 'react'...)*

------
https://chatgpt.com/codex/tasks/task_e_6840966f3dd48321a326b40c9df9dcc6